### PR TITLE
Updated the link for the CHP model

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -42,7 +42,7 @@ The [component models assembly tool](#component-models-assembly-tool) will sampl
 Nuclear EDF - Part of SMS++ / Plan4Res: https://github.com/iDesignRES/Plan4Res-SMS \
 Solar - https://git.code.tecnalia.com/swt-tecu/idesignres.git \
 Wind - https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/tree/dev_windpower \
-CHP - https://github.com/EnergyModelsX/EnergyModelsHeat.jl/tree/main/submodels/bioCHP_plant
+CHP - https://github.com/iDesignRES/CHP_modelling
 
 ## Component models assembly tool
 


### PR DESCRIPTION
We moved the CHP model to the corresponding repository in the iDEsignRES organization. I do not know who of you wants to approve and merge it, but I thought it is better to have a proper PR for it.