### PR TITLE
Updated the links to Tecnalia models and the assembly tool

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,18 +15,18 @@ The represented components span from primary energy sources, energy conversion a
 The detailed system models are derived for individual energy carriers, *e.g.*, electricity and natural gas.
 These models are available for detailed analyses of these systems.
 
-EDF models - https://github.com/iDesignRES/Plan4Res-SMS \
-POMATWO - https://github.com/iDesignRES/POMATWO \
-MGET/GGM - https://github.com/iDesignRES/GGM
+EDF models - <https://github.com/iDesignRES/Plan4Res-SMS> \
+POMATWO - <https://github.com/iDesignRES/POMATWO> \
+MGET/GGM - <https://github.com/iDesignRES/GGM>
 
 ### Energy consumer models
 
 Detailed models for the energy consumers of a given area/industry type are developed.
 The modules can be used stand-alone or provide data to be used together with the [component models assembly tool](#component-models-assembly-tool).
 
-Deusto - https://github.com/iDesignRES/IDR-IIsim \
-Building mdoels - https://github.com/iDesignRES/Tecnalia_Building-Stock-Energy-Model \
-Transport - https://github.com/iDesignRES/transcomp
+Deusto - <https://github.com/iDesignRES/IDR-IIsim> \
+Building models - <https://github.com/iDesignRES/Tecnalia_Building-Stock-Energy-Model> \
+Transport - <https://github.com/iDesignRES/transcomp>
 
 ### Multi-parameter component models for direct integration
 
@@ -39,10 +39,10 @@ A detailed description with links to the individual models can be found in the r
 The stand-alone component models have detailed operational analysis capabilities.
 The [component models assembly tool](#component-models-assembly-tool) will sample data from the component model outputs and use in the assessment of the integrated, multi-carrier energy system operations.
 
-Nuclear EDF - Part of SMS++ / Plan4Res: https://github.com/iDesignRES/Plan4Res-SMS \
-Solar - https://github.com/iDesignRES/Tecnalia_Solar-Energy-Model \
-Wind - https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/tree/dev_windpower \
-CHP - https://github.com/iDesignRES/CHP_modelling
+Nuclear EDF - Part of SMS++ / Plan4Res: <https://github.com/iDesignRES/Plan4Res-SMS> \
+Solar - <https://github.com/iDesignRES/Tecnalia_Solar-Energy-Model> \
+Wind - <https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/tree/dev_windpower> \
+CHP - <https://github.com/iDesignRES/CHP_modelling>
 
 ## Component models assembly tool
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,4 +1,4 @@
-## iDesignRes
+# iDesignRes
 
 iDesignRes is an European Union-funded research initiative aimed at advancing the integration of renewable energy across Europe.
 The project brings together 22 partners from 11 countries to develop open-source tools that assist public authorities and network operators in planning and optimizing the adoption of low and zero-emission energy sources at regional, national, and European levels.
@@ -25,7 +25,7 @@ Detailed models for the energy consumers of a given area/industry type are devel
 The modules can be used stand-alone or provide data to be used together with the [component models assembly tool](#component-models-assembly-tool).
 
 Deusto - https://github.com/iDesignRES/IDR-IIsim \
-Technalia buildings - https://github.com/iDesignRES/Tecnalia \
+Building mdoels - https://github.com/iDesignRES/Tecnalia_Building-Stock-Energy-Model \
 Transport - https://github.com/iDesignRES/transcomp
 
 ### Multi-parameter component models for direct integration
@@ -40,12 +40,15 @@ The stand-alone component models have detailed operational analysis capabilities
 The [component models assembly tool](#component-models-assembly-tool) will sample data from the component model outputs and use in the assessment of the integrated, multi-carrier energy system operations.
 
 Nuclear EDF - Part of SMS++ / Plan4Res: https://github.com/iDesignRES/Plan4Res-SMS \
-Solar - https://git.code.tecnalia.com/swt-tecu/idesignres.git \
+Solar - https://github.com/iDesignRES/Tecnalia_Solar-Energy-Model \
 Wind - https://github.com/EnergyModelsX/EnergyModelsRenewableProducers.jl/tree/dev_windpower \
 CHP - https://github.com/iDesignRES/CHP_modelling
 
 ## Component models assembly tool
 
 The component models assembly tool is an extension to the [EnergyModelsX (EMX)](https://github.com/EnergyModelsX) framework.
-It will be available from April 2025.
 It is combining the individual component models through either direct integration, linking, or sampling of data from the different tools.
+The core feature is the receding horizon framework implemented in the Julia package [`EnergyModelsRecedingHorizon.jl`](https://github.com/EnergyModelsX/EnergyModelsRecedingHorizon.jl).
+The integration of new components into the `EMX` framework can be tested through the package [`EnergyModelsCompliance.jl`](https://github.com/EnergyModelsX/EnergyModelsCompliance.jl).
+
+All packages within the `EnergyModelsX` framework are also available *via* the general registry of Julia.


### PR DESCRIPTION
After a discussion with Tecnalia, we decided that it makes sense to create to different repositories for the building module and the solar PV module. As a consequence, this PR updates the link to the respective modules.

I furthermore realized that the assembly tool links (and other packages we developed for April) were not included in the link set. This is fixed as well.